### PR TITLE
Make MIDI device detection more robust

### DIFF
--- a/Classes/LaunchpadMiniMk1.sc
+++ b/Classes/LaunchpadMiniMk1.sc
@@ -44,7 +44,7 @@ LaunchpadMiniMk1 {
     var <channel = 0;
     var <verbose = true;
 
-    classvar <midiDeviceName = "Launchpad Mini", midiPortName = "Launchpad Mini";
+    classvar <midiDeviceName = "Launchpad Mini";
     classvar <deviceButtonNotes, <sideButtonNotes, <topButtonCCNums;
 
     *new{
@@ -124,8 +124,7 @@ LaunchpadMiniMk1 {
         if(devices.size < 1, {
             "No device found - may only be used with GUI".warn;
         }, {
-
-            deviceMidiOut = MIDIOut.newByName(midiDeviceName, midiPortName).latency_(0);
+            deviceMidiOut = MIDIOut.newByName(devices[0].device, devices[0].name).latency_(0);
 
             // A dirty hack to connect the device
             MIDIClient.sources.do{|src, srcNum|


### PR DESCRIPTION
The current code to set up the midi device breaks for me with the following error:

```
ERROR: Failed to find MIDIOut port  Launchpad Mini Launchpad Mini
```

I'm on NixOS, my launchpad mini shows up in SC as `MIDIEndPoint("Launchpad Mini", "Launchpad Mini MIDI 1", 1310720)`. There may be differences between different OSes? This patch tries to make the setup logic a bit more robust.